### PR TITLE
has wrong peer of react-redux@^4.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-redux-router",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "Ari Bouius <abouius@rentpath.com>",
   "main": "./lib/index.js",
   "module": "es/index.js",
@@ -53,7 +53,10 @@
   },
   "peerDependencies": {
     "react": "^15.3.1",
-    "react-redux": "^4.4.5",
+    "react-redux": "^4.0.0 || ^5.0.0",
     "redux": "^3.6.0"
+  },
+  "engines": {
+    "node": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Gets rid of warning when installing package:
```
warning "@rentpath/react-redux-router@2.1.0" has incorrect peer dependency "react-redux@^4.4.5".
```