### PR TITLE
Update status in transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-redux-router",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "author": "Ari Bouius <abouius@rentpath.com>",
   "main": "./lib/index.js",
   "module": "es/index.js",

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -51,6 +51,7 @@ class Router extends PureComponent {
   transition(location, status) {
     transition({
       location,
+      status,
       strict: this.props.strict,
       routes: this.props.routes,
       dispatch: this.props.dispatch,
@@ -58,11 +59,10 @@ class Router extends PureComponent {
         this.route = {
           ...result.route,
           ...this.props.router.route,
-          ...(status ? { status } : {}),
         }
         if (this.props.onChange) {
           this.props.onChange({
-            route: this.route,
+            route: result.route,
             params: result.params,
             location,
           })

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -48,7 +48,7 @@ class Router extends PureComponent {
     }
   }
 
-  transition(location) {
+  transition(location, status) {
     transition({
       location,
       strict: this.props.strict,
@@ -58,10 +58,11 @@ class Router extends PureComponent {
         this.route = {
           ...result.route,
           ...this.props.router.route,
+          ...(status ? { status } : {}),
         }
         if (this.props.onChange) {
           this.props.onChange({
-            route: result.route,
+            route: this.route,
             params: result.params,
             location,
           })

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -69,7 +69,7 @@ export default (
           history[methods[action.method]](buildPath(action.location))
         }
         if (router) {
-          router.transition(action.location)
+          router.transition(action.location, action.status)
         }
 
         return resp

--- a/src/transition.js
+++ b/src/transition.js
@@ -10,6 +10,7 @@ export default async (options = {}) => {
     location = {},
     dispatch,
     beforeRender,
+    status,
   } = options
 
   const route = {}
@@ -52,7 +53,9 @@ export default async (options = {}) => {
   route.loading = true
 
   // ensure route has a status code
-  if (!route.status) {
+  if (status) {
+    route.status = status
+  } else if (!route.status) {
     route.status = branches.length ? STATUS_OK : STATUS_NOT_FOUND
   }
 


### PR DESCRIPTION
If a location change occurs (e.g. calling `replace()` in a component), the updated status should be passed along to `onChange`. This is to allow hooking in to `onChange` so that server-side 301/302 redirects can work within a component's `constructor()` or `componentWillMount()`.