### PR TITLE
Add getState to route resolve to allow the use of theme loading

### DIFF
--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -10,6 +10,7 @@ class Router extends PureComponent {
     routes: PropTypes.array.isRequired,
     render: PropTypes.func,
     dispatch: PropTypes.func.isRequired,
+    getState: PropTypes.func.isRequired,
     initialLocation: PropTypes.object,
     strict: PropTypes.bool,
     onChange: PropTypes.func,
@@ -52,6 +53,7 @@ class Router extends PureComponent {
     transition({
       location,
       status,
+      getState: this.props.getState,
       strict: this.props.strict,
       routes: this.props.routes,
       dispatch: this.props.dispatch,

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -11,6 +11,7 @@ export default async ({
   }
   return match({
     dispatch: store.dispatch,
+    getState: store.getState,
     location: store.dispatch(push(location)).location,
     ...options,
   })

--- a/src/transition.js
+++ b/src/transition.js
@@ -93,7 +93,7 @@ export default async (options = {}) => {
         // This has to be done because we get getState on initial match
         // And store on subsequent client transitions
         // At some point we could switch it to use store fully
-        getState: getState || store.getState,
+        getState: getState || (store || { getState: () => ({}) }).getState,
       })
     )
     promises.push(response.then(({

--- a/src/transition.js
+++ b/src/transition.js
@@ -9,6 +9,8 @@ export default async (options = {}) => {
     routes = [],
     location = {},
     dispatch,
+    getState,
+    store,
     beforeRender,
     status,
   } = options
@@ -83,7 +85,17 @@ export default async (options = {}) => {
   promises = []
   Object.keys(resolvers).forEach(index => {
     const resolver = resolvers[index]
-    const response = Promise.resolve(resolver({ route, params, location }))
+    const response = Promise.resolve(
+      resolver({
+        route,
+        params,
+        location,
+        // This has to be done because we get getState on initial match
+        // And store on subsequent client transitions
+        // At some point we could switch it to use store fully
+        getState: getState || store.getState,
+      })
+    )
     promises.push(response.then(({
       action,
       component,
@@ -144,6 +156,7 @@ export default async (options = {}) => {
     strict,
     params,
     location,
+    getState,
   }
 
   // this callback is useful for ensuring


### PR DESCRIPTION
This lets us use getState in route resolves to load and unload our themes. This needs to happen in the resolve because we want to load these before the route changes and we get new components