### PR TITLE
Adding dispatch to resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-redux-router",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Ari Bouius <abouius@rentpath.com>",
   "main": "./lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-redux-router",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "author": "Ari Bouius <abouius@rentpath.com>",
   "main": "./lib/index.js",
   "module": "es/index.js",

--- a/src/transition.js
+++ b/src/transition.js
@@ -94,6 +94,7 @@ export default async (options = {}) => {
         // And store on subsequent client transitions
         // At some point we could switch it to use store fully
         getState: getState || (store || { getState: () => ({}) }).getState,
+        dispatch,
       })
     )
     promises.push(response.then(({


### PR DESCRIPTION
Adding dispatch to resolve so we can load listings or pdp data on client transition, so we don't need to load first in the thunk before transitioning